### PR TITLE
6 - Get comments for a particular article

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -234,7 +234,7 @@ describe('/api/articles/:article_id/comments', () => {
       .get('/api/articles/9999/comments')
       .expect(404)
       .then(({ body }) => {
-        expect(body.msg).toBe('Resource not found');
+        expect(body.msg).toBe('article_id 9999 not found');
       });
   });
 });

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -186,7 +186,7 @@ describe('/api/articles/:article_id/comments', () => {
   /* 
     - GET
     - respond with 200 status
-    - respond with 404 if article is found but no comments exist
+    - respond with 200 if article is found but no comments exist
     - respond with 404 when no article found with article_id
   */
   test('GET:200 should return an array of comments for a given article', () => {
@@ -197,15 +197,21 @@ describe('/api/articles/:article_id/comments', () => {
         const { comments } = response.body;
 
         expect(comments).toHaveLength(11);
-        expect(comments).toBeSortedBy;
-        comments.forEach((comment) => {
-          expect(typeof comment.comment_id).toBe('number');
-          expect(typeof comment.votes).toBe('number');
-          expect(typeof comment.created_at).toBe('string');
-          expect(typeof comment.author).toBe('string');
-          expect(typeof comment.body).toBe('string');
-          expect(typeof comment.article_id).toBe('number');
+        expect(comments).toBeSortedBy('created_at', {
+          descending: true,
         });
+        expect(comments).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              comment_id: expect.any(Number),
+              votes: expect.any(Number),
+              created_at: expect.any(String),
+              author: expect.any(String),
+              body: expect.any(String),
+              article_id: expect.any(Number),
+            }),
+          ])
+        );
       });
   });
   test('GET:200 should return array of comments sorted by date in descending order', () => {
@@ -220,10 +226,10 @@ describe('/api/articles/:article_id/comments', () => {
         });
       });
   });
-  test('GET:404 should respond with appropriate message and status code when article exists but has no comments', () => {
+  test('GET:200 should respond with appropriate message and status code when article exists but has no comments', () => {
     return request(app)
       .get('/api/articles/12/comments')
-      .expect(404)
+      .expect(200)
       .then(({ body }) => {
         expect(body.msg).toBe('No comments found for article');
       });
@@ -235,6 +241,14 @@ describe('/api/articles/:article_id/comments', () => {
       .expect(404)
       .then(({ body }) => {
         expect(body.msg).toBe('article_id 9999 not found');
+      });
+  });
+  test('GET:400 should return an appropriate status code and error message when given an invalid ID that is not a number', () => {
+    return request(app)
+      .get('/api/articles/a/comments')
+      .expect(400)
+      .then(({ body }) => {
+        expect(body.msg).toBe('Bad Request');
       });
   });
 });

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -181,3 +181,65 @@ describe('/api/articles', () => {
       });
   });
 });
+
+describe('/api/articles/:article_id/comments', () => {
+  /* 
+    - GET
+    - respond with 200 status
+    - respond with 204 if article is found but no comments exist
+    - respond with 404 when no article found with article_id
+  */
+  test('GET:200 should return an array of comments for a given article', () => {
+    return request(app)
+      .get('/api/articles/1/comments')
+      .expect(200)
+      .then((response) => {
+        const { comments } = response.body;
+
+        expect(comments).toHaveLength(11);
+        expect(comments).toBeSortedBy;
+        comments.forEach((comment) => {
+          expect(typeof comment.comment_id).toBe('number');
+          expect(typeof comment.votes).toBe('number');
+          expect(typeof comment.created_at).toBe('string');
+          expect(typeof comment.author).toBe('string');
+          expect(typeof comment.body).toBe('string');
+          expect(typeof comment.article_id).toBe('number');
+        });
+      });
+  });
+  test('GET:200 should return array of comments sorted by date in descending order', () => {
+    return request(app)
+      .get('/api/articles/1/comments')
+      .expect(200)
+      .then((response) => {
+        const { comments } = response.body;
+
+        expect(comments).toBeSortedBy('created_at', {
+          descending: true,
+        });
+      });
+  });
+  test('GET:404 should respond with appropriate message and status code when article exists but has no comments', () => {
+    return request(app)
+      .get('/api/articles/12/comments')
+      .expect(404)
+      .then(({ body }) => {
+        expect(body.msg).toBe('No comments found for article');
+      });
+  });
+
+  /* NOTE - This has only passed 0.5% of the time as the promises resolve/reject with race conditions. I would have suggested having a message to the client indicating the article they search for doesn't exist but the comments promise seems to reolve/reject first sending a message indicating no comments exist for article (which is also technically true) 
+  
+  Spoke to Poonam about it but haven't received advice about it yet.
+  */
+
+  // test('GET:404 should respond with appropriate status code and error message when article with the ID supplied does not exist', () => {
+  //   return request(app)
+  //     .get('/api/articles/9999/comments')
+  //     .expect(404)
+  //     .then(({ body }) => {
+  //       expect(body.msg).toBe('Article does not exist');
+  //     });
+  // });
+});

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -229,17 +229,12 @@ describe('/api/articles/:article_id/comments', () => {
       });
   });
 
-  /* NOTE - This has only passed 0.5% of the time as the promises resolve/reject with race conditions. I would have suggested having a message to the client indicating the article they search for doesn't exist but the comments promise seems to reolve/reject first sending a message indicating no comments exist for article (which is also technically true) 
-  
-  Spoke to Poonam about it but haven't received advice about it yet.
-  */
-
-  // test('GET:404 should respond with appropriate status code and error message when article with the ID supplied does not exist', () => {
-  //   return request(app)
-  //     .get('/api/articles/9999/comments')
-  //     .expect(404)
-  //     .then(({ body }) => {
-  //       expect(body.msg).toBe('Article does not exist');
-  //     });
-  // });
+  test('GET:404 should respond with appropriate status code and error message when article with the ID supplied does not exist', () => {
+    return request(app)
+      .get('/api/articles/9999/comments')
+      .expect(404)
+      .then(({ body }) => {
+        expect(body.msg).toBe('Resource not found');
+      });
+  });
 });

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -186,7 +186,7 @@ describe('/api/articles/:article_id/comments', () => {
   /* 
     - GET
     - respond with 200 status
-    - respond with 204 if article is found but no comments exist
+    - respond with 404 if article is found but no comments exist
     - respond with 404 when no article found with article_id
   */
   test('GET:200 should return an array of comments for a given article', () => {

--- a/app.js
+++ b/app.js
@@ -4,6 +4,7 @@ const { getEndpoints } = require('./controllers/api.controller');
 const {
   getArticleById,
   getArticles,
+  getCommentsForArticle,
 } = require('./controllers/articles.controller');
 const {
   handleCustomErrors,
@@ -21,6 +22,7 @@ app.get('/api', getEndpoints);
 // /api/articles
 app.get('/api/articles', getArticles);
 app.get('/api/articles/:article_id', getArticleById);
+app.get('/api/articles/:article_id/comments', getCommentsForArticle);
 
 // /api/topics
 app.get('/api/topics', getTopics);

--- a/controllers/articles.controller.js
+++ b/controllers/articles.controller.js
@@ -27,11 +27,8 @@ exports.getArticleById = (req, res, next) => {
 exports.getCommentsForArticle = (req, res, next) => {
   const { article_id } = req.params;
 
-  Promise.all([
-    getAllCommentsForArticle(article_id),
-    selectArticleById(article_id),
-  ])
-    .then(([comments]) => {
+  getAllCommentsForArticle(article_id)
+    .then((comments) => {
       res.status(200).send({ comments });
     })
     .catch(next);

--- a/controllers/articles.controller.js
+++ b/controllers/articles.controller.js
@@ -2,6 +2,7 @@ const {
   selectArticleById,
   getAllArticles,
 } = require('../models/articles.model');
+const { getAllCommentsForArticle } = require('../models/comments.model');
 
 exports.getArticles = (req, res, next) => {
   const { order } = req.query;
@@ -15,9 +16,23 @@ exports.getArticles = (req, res, next) => {
 
 exports.getArticleById = (req, res, next) => {
   const { article_id } = req.params;
+
   selectArticleById(article_id)
     .then((article) => {
       res.status(200).send({ article });
+    })
+    .catch(next);
+};
+
+exports.getCommentsForArticle = (req, res, next) => {
+  const { article_id } = req.params;
+
+  Promise.all([
+    getAllCommentsForArticle(article_id),
+    selectArticleById(article_id),
+  ])
+    .then(([comments]) => {
+      res.status(200).send({ comments });
     })
     .catch(next);
 };

--- a/db/seeds/utils.js
+++ b/db/seeds/utils.js
@@ -1,3 +1,6 @@
+const format = require('pg-format');
+const db = require('../connection');
+
 exports.convertTimestampToDate = ({ created_at, ...otherProperties }) => {
   if (!created_at) return { ...otherProperties };
   return { created_at: new Date(created_at), ...otherProperties };
@@ -18,5 +21,15 @@ exports.formatComments = (comments, idLookup) => {
       author: created_by,
       ...this.convertTimestampToDate(restOfComment),
     };
+  });
+};
+
+exports.checkExists = (table, column, value) => {
+  const qryStr = format('SELECT * FROM %I WHERE %I = $1;', table, column);
+
+  return db.query(qryStr, [value]).then(({ rows }) => {
+    return rows.length === 0
+      ? Promise.reject({ status: 404, msg: 'Resource not found' })
+      : rows;
   });
 };

--- a/db/seeds/utils.js
+++ b/db/seeds/utils.js
@@ -29,7 +29,7 @@ exports.checkExists = (table, column, value) => {
 
   return db.query(qryStr, [value]).then(({ rows }) => {
     return rows.length === 0
-      ? Promise.reject({ status: 404, msg: 'Resource not found' })
+      ? Promise.reject({ status: 404, msg: `${column} ${value} not found` })
       : rows;
   });
 };

--- a/endpoints.json
+++ b/endpoints.json
@@ -26,7 +26,7 @@
       ]
     }
   },
-  "GET /api/articles:article_id": {
+  "GET /api/articles/:article_id": {
     "description": "serves a single object of an article",
     "queries": [],
     "exampleResponse": {
@@ -40,6 +40,22 @@
         "votes": 0,
         "article_img_url": "https://images.pexels.com/photos/158651/news-newsletter-newspaper-information-158651.jpeg?w=700&h=700"
       }
+    }
+  },
+  "GET /api/articles:article_id/comments": {
+    "description": "serves an array of all comments for an article",
+    "queries": ["order"],
+    "exampleResponse": {
+      "comments": [
+        {
+          "comment_id": 1,
+          "votes": 0,
+          "created_at": "2018-05-30T15:59:13.341Z",
+          "author": "weegembump",
+          "body": "Text from the comment..",
+          "article_id": 7
+        }
+      ]
     }
   }
 }

--- a/errors/index.js
+++ b/errors/index.js
@@ -1,5 +1,5 @@
 exports.handleCustomErrors = (err, req, res, next) => {
-  if (err.status && err.msg) {
+  if (err.status) {
     res.status(err.status).send({ msg: err.msg });
   } else {
     next(err);

--- a/models/comments.model.js
+++ b/models/comments.model.js
@@ -11,7 +11,7 @@ exports.getAllCommentsForArticle = (article_id) => {
     if (rows.length === 0) {
       return checkExists('articles', 'article_id', article_id).then(() => {
         return Promise.reject({
-          status: 404,
+          status: 200,
           msg: 'No comments found for article',
         });
       });

--- a/models/comments.model.js
+++ b/models/comments.model.js
@@ -1,4 +1,5 @@
 const db = require('../db/connection');
+const { checkExists } = require('../db/seeds/utils');
 
 exports.getAllCommentsForArticle = (article_id) => {
   const query = `
@@ -7,8 +8,15 @@ exports.getAllCommentsForArticle = (article_id) => {
     ORDER BY created_at DESC;`;
 
   return db.query(query, [article_id]).then(({ rows }) => {
-    return rows.length === 0
-      ? Promise.reject({ status: 404, msg: 'No comments found for article' })
-      : rows;
+    if (rows.length === 0) {
+      return checkExists('articles', 'article_id', article_id).then(() => {
+        return Promise.reject({
+          status: 404,
+          msg: 'No comments found for article',
+        });
+      });
+    } else {
+      return rows;
+    }
   });
 };

--- a/models/comments.model.js
+++ b/models/comments.model.js
@@ -1,0 +1,14 @@
+const db = require('../db/connection');
+
+exports.getAllCommentsForArticle = (article_id) => {
+  const query = `
+    SELECT * FROM comments 
+    WHERE article_id = $1
+    ORDER BY created_at DESC;`;
+
+  return db.query(query, [article_id]).then(({ rows }) => {
+    return rows.length === 0
+      ? Promise.reject({ status: 404, msg: 'No comments found for article' })
+      : rows;
+  });
+};


### PR DESCRIPTION
Created endpoint for getting comments for a particular article.

Unable to test for an article that does not exist.

Using promises to get the articleById and to get the comments and would assume that it would return message about article not existing but the comments promise resolves/rejects first 99.9% of the time so it states that no comments exist (which technically is true but not very user friendly)

Spoke to Poonam about it but not heard anything back and don't want to be stuck on a single test not passing due to race conditions